### PR TITLE
checkinfo should look for "Tags:" and not just "Tags"

### DIFF
--- a/submitqc
+++ b/submitqc
@@ -1452,7 +1452,7 @@ checkinfo() {
   fi
 
   for FIELD in Change-log Comments Description Version Author Original-site \
-  Copying-policy "Extension[-_]by" Tags Current; do
+  Copying-policy "Extension[-_]by" "Tags:" Current; do
     if [ -z "$(cat "$I" | grep "$FIELD" | awk '{print $2}')" ]; then
       [ -z $ERR ] && ERR=1 && echo ""
       echo -e "\t${RED}$FIELD missing or invalid. Fix before submitting.${NORMAL}"


### PR DESCRIPTION
A field named exactly "Tags:" must exist in the .info file. If not, the script that builds tags.db for the repository will not add the extension to  tags.db. If extension is not in tags.db, user will be unable to find the extension when searching for it using tce or Apps.